### PR TITLE
Update readme for building on Windows

### DIFF
--- a/README-Ecoviz-Windows.md
+++ b/README-Ecoviz-Windows.md
@@ -18,6 +18,7 @@ Before you can run Ecoviz, ensure that you have the following tools and librarie
 1. **Download and Install Qt6**:
    - Visit the [official Qt website](https://www.qt.io/download) to download the Qt6 installer.
    - Run the installer and follow the on-screen instructions.
+     - **Note**: Ensure that you install the `msvc` (**not** `mingw`) version of Qt6, which can be checked under **Customize > Qt 6.X.X** during installation.
    
 2. **Include QtCharts Module**:
    - During the installation process, ensure that you select the **QtCharts** module to be installed. This module is essential for rendering charts and visualizations within Ecoviz.
@@ -43,7 +44,7 @@ Before you can run Ecoviz, ensure that you have the following tools and librarie
    - **Boost**:
      - Right-click on the solution in the **Solution Explorer**.
      - Select **"Manage NuGet Packages for Solution..."**.
-     - In the **Browse** tab, search for `boost` and install it for the Ecoviz project.
+     - In the **Browse** tab, search for `boost` and install version `v1.85.0` for the Ecoviz project.
    
    - **Boost.Serialization**:
      - In the **NuGet Package Manager**, search for `boost_serialization-vc143` (specific to Visual Studio 2022) and install it for the Ecoviz project.

--- a/README.md
+++ b/README.md
@@ -4,16 +4,18 @@ Ecoviz is a C++ application developed using the Qt6 framework for visualizing ec
 
 ## Table of Contents
 
-1. [Prerequisites](#prerequisites)
-2. [Installation](#installation)
-   - [Ubuntu Installation](#ubuntu-installation)
-   - [Windows Installation](#windows-installation)
-3. [Building and Running Ecoviz](#building-and-running-ecoviz)
-   - [Ubuntu](#ubuntu)
-   - [Windows](#windows)
-4. [Rendering with Mitsuba](#rendering-with-mitsuba)
-5. [Project Structure](#project-structure)
-6. [Description](#description)
+- [Ecoviz - Ecosystem Visualization Application](#ecoviz---ecosystem-visualization-application)
+  - [Table of Contents](#table-of-contents)
+  - [Prerequisites](#prerequisites)
+  - [Installation](#installation)
+    - [Ubuntu Installation](#ubuntu-installation)
+    - [Windows Installation](#windows-installation)
+  - [Building and Running Ecoviz](#building-and-running-ecoviz)
+    - [Ubuntu](#ubuntu)
+    - [Windows](#windows)
+  - [Rendering with Mitsuba](#rendering-with-mitsuba)
+  - [Project Structure](#project-structure)
+  - [Description](#description)
 
 ## Prerequisites
 
@@ -50,6 +52,7 @@ Follow these steps to set up Ecoviz on Ubuntu:
 
 1. **Install Qt6**:
    - Download the installer from the [official Qt website](https://www.qt.io/download) and follow the installation steps.
+   - During installation, ensure that you install the `msvc` (**not** `mingw`) version of Qt6, which can be checked under **Customize > Qt 6.X.X**.
    - During installation, ensure that you include the **QtCharts** module.
    - After installation, you need to set the `QT6DIR` environment variable:
      1. Open the **Start Menu** and search for "Environment Variables".
@@ -61,7 +64,7 @@ Follow these steps to set up Ecoviz on Ubuntu:
 2. **Set Up the Visual Studio Project**:
    - Open the Ecoviz Visual Studio solution (`.sln`) using **Visual Studio 2022**.
    - Open the **NuGet Package Manager** and install the following packages:
-     - `boost`
+     - `boost v1.85.0`
      - `boost_serialization-vc143` (specifically for Visual Studio 2022)
      - `glm`
    - Set up the project properties:


### PR DESCRIPTION
Updated readme to catch some small problems when building on Windows:

- By default, Qt installer will install the mingw version instead of the msvc version, if you have mingw installed.
- Anything newer than boost v1.85.0 (from nuget) causes compilation errors.
